### PR TITLE
chore: add `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+title: RABBIT
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Natarajan
+    family-names: Chidambaram
+    email: natarajan.chidambaram@umons.ac.be
+    orcid: 'https://orcid.org/0000-0002-2295-8928'
+    affiliation: UMons
+  - given-names: Tom
+    family-names: Mens
+    email: tom.mens@umons.ac.be
+    affiliation: UMons
+    orcid: 'https://orcid.org/0000-0003-3636-5020'
+  - given-names: Alexandre
+    family-names: Decan
+    email: alexandre.decan@umons.ac.be
+    orcid: 'https://orcid.org/0000-0002-5824-5823'
+    affiliation: UMons
+identifiers:
+  - type: doi
+    value: 10.1145/3643991.3644877
+    description: >-
+      RABBIT: A tool for identifying bot accounts based on
+      their recent GitHub event history
+  - type: swh
+    value: 'swh:1:dir:42a3619b53e990a1df7624865b46edbd6366f3c2'
+    description: >-
+      RABBIT: A tool for identifying bot accounts based on
+      their recent GitHub event history
+repository-code: 'https://github.com/natarajan-chidambaram/RABBIT'
+abstract: >-
+  RABBIT is a recursive acronym for "RABBIT is an
+  Activity-Based Bot Identification Tool". It is based on
+  BIMBAS (stands for Bot Identification Model Based on
+  Activity Sequences), a binary classification model to
+  identify bot contributors based on their recent activities
+  in GitHub.
+keywords:
+  - bot
+  - classification
+license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,45 +1,26 @@
 cff-version: 1.2.0
-title: RABBIT
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
-type: software
-authors:
-  - given-names: Natarajan
-    family-names: Chidambaram
-    email: natarajan.chidambaram@umons.ac.be
-    orcid: 'https://orcid.org/0000-0002-2295-8928'
-    affiliation: UMons
-  - given-names: Tom
-    family-names: Mens
-    email: tom.mens@umons.ac.be
-    affiliation: UMons
-    orcid: 'https://orcid.org/0000-0003-3636-5020'
-  - given-names: Alexandre
-    family-names: Decan
-    email: alexandre.decan@umons.ac.be
-    orcid: 'https://orcid.org/0000-0002-5824-5823'
-    affiliation: UMons
-identifiers:
-  - type: doi
-    value: 10.1145/3643991.3644877
-    description: >-
-      RABBIT: A tool for identifying bot accounts based on
-      their recent GitHub event history
-  - type: swh
-    value: 'swh:1:dir:42a3619b53e990a1df7624865b46edbd6366f3c2'
-    description: >-
-      RABBIT: A tool for identifying bot accounts based on
-      their recent GitHub event history
-repository-code: 'https://github.com/natarajan-chidambaram/RABBIT'
-abstract: >-
-  RABBIT is a recursive acronym for "RABBIT is an
-  Activity-Based Bot Identification Tool". It is based on
-  BIMBAS (stands for Bot Identification Model Based on
-  Activity Sequences), a binary classification model to
-  identify bot contributors based on their recent activities
-  in GitHub.
-keywords:
-  - bot
-  - classification
-license: Apache-2.0
+title: "RABBIT: A tool for identifying bot accounts based on their recent GitHub event history"
+url: 'https://github.com/natarajan-chidambaram/RABBIT'
+preferred-citation:
+  type: article
+  authors:
+    - given-names: Natarajan
+      family-names: Chidambaram
+      email: natarajan.chidambaram@umons.ac.be
+      orcid: 'https://orcid.org/0000-0002-2295-8928'
+      affiliation: UMons
+    - given-names: Tom
+      family-names: Mens
+      email: tom.mens@umons.ac.be
+      affiliation: UMons
+      orcid: 'https://orcid.org/0000-0003-3636-5020'
+    - given-names: Alexandre
+      family-names: Decan
+      email: alexandre.decan@umons.ac.be
+      orcid: 'https://orcid.org/0000-0002-5824-5823'
+      affiliation: UMons
+  doi: "10.1145/3643991.3644877"
+  title: "RABBIT: A tool for identifying bot accounts based on their recent GitHub event history"


### PR DESCRIPTION
Hey!

GitHub supports a specific citation file format (`CITATION.cff`). Having this file would enhance the visibility and proper citation of RABBIT directly from the GitHub repository page. More details can be found in the [GitHub documentation on citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

Would you be interested in adding such a file to the project?

When Github detect such a file in a repo, a new link is displayed on the right side.

Find some examples of this at:
- https://github.com/typst/typst/pull/4109
- https://github.com/NixOS/nix/pull/10732
- https://github.com/semver/semver/pull/905