### PR TITLE
Fix missing argument when no activity is found.

### DIFF
--- a/rabbit.py
+++ b/rabbit.py
@@ -349,7 +349,7 @@ def MakePrediction(contributor, apikey, min_events, min_confidence, max_queries,
                                                 activities = activities.shape[0]
                                                 )
             else:
-                result = frame_direct_result('Unknown', result_cols, contributor)
+                result = frame_direct_result('Unknown', '-', result_cols, contributor)
             result = format_result(result, verbose)
     
     elif(query_failed):


### PR DESCRIPTION
When we use RABBIT to predict the type of a contributor that has the following conditions : 
1. Is considered as a "User" by the API 
2. Has more than the minimum of events (default=5)
3. The activity mapping cannot compute any activity (only unknown activities)

An error occur because the confidence argument is missing in a call of `frame_direct_result()`.


This PR solves this issue by simply adding the missing argument.